### PR TITLE
Add "Back to Top" Links in README for Better Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,11 @@ Feel free to fork, enhance, and contribute to the project!
 📧 Email: [kanikasin216@gmail.com](mailto:kanikasin216@gmail.com)
 
 
+<p align="center">
+  <a href="#top" style="font-size: 18px; padding: 8px 16px; display: inline-block; border: 1px solid #ccc; border-radius: 6px; text-decoration: none;">
+    ⬆️ Back to Top
+  </a>
+</p>
 
 
 


### PR DESCRIPTION
The current README.md is too long and contains multiple sections. Scrolling through it can be cumbersome, especially for new users or contributors accessing it on smaller screens.

💡 Proposed Solution
Add [🔝 Back to Top] links at the end of major sections in the README

Optionally add a top anchor like (though GitHub supports #readme by default)

Maintain consistent formatting across all sections

Please assign this as level 1

Issue number #20 